### PR TITLE
chore: config 파일 가져오는 스크립트 작성 #7

### DIFF
--- a/fetchConfig.sh
+++ b/fetchConfig.sh
@@ -1,0 +1,5 @@
+git clone git@github.com:bengHak/OZeon-Config.git
+mv OZeon-Config/BuildConfigurations/ .
+mv OZeon-Config/Signing/master.key ./Tuist/master.key
+mv OZeon-Config/Signing/Signing ./Tuist/Signing
+rm -rf OZeon-Config


### PR DESCRIPTION
closes #7 

- config 일일이 세팅해주는게 불편해서 스크립트로 불러올 수 있게 작업함.
- 아래처럼 쉘에 명령어 입력하면 가져올 수 있음.

```shell
// 권한 설정
chmod 755 fetchConfig.sh

// 가져오는 스크립트 실행
./fetchConfig.sh
```