### PR TITLE
[Fix] Move onboarding, mainTabBar to sub-node of Root node #75

### DIFF
--- a/Projects/Modules/PresentationKit/Sources/Features/Login/LoginView.swift
+++ b/Projects/Modules/PresentationKit/Sources/Features/Login/LoginView.swift
@@ -45,7 +45,7 @@ public struct LoginView: View {
     }
     
     public var body: some View {
-        WithViewStore(self.store, observe: { $0 }) { _ in
+        WithViewStore(self.store, observe: { $0 }) { viewStore in
             VStack(spacing: 0) {
                 VStack {
                     Spacer()
@@ -78,7 +78,7 @@ public struct LoginView: View {
                 .padding(.bottom, Constants.Sizes.loginButtonBottomPadding)
 
                 Button(action: {
-                    print("둘러보기")
+                    viewStore.send(.didTapLookAround)
                 }, label: {
                     Text(Constants.Strings.lookAround)
                         .font(.Title2.regular)
@@ -94,11 +94,9 @@ public struct LoginView: View {
 #if DEBUG
 struct LoginView_Previews: PreviewProvider {
     static var previews: some View {
-        LoginView(
-            store: Store(initialState: Login.State()) {
-                Login()
-            }
-        )
+        LoginView(store: Store(initialState: Login.State()) {
+            Login()
+        })
     }
 }
 #endif

--- a/Projects/Modules/PresentationKit/Sources/Features/MainTabBar/MainTabBar.swift
+++ b/Projects/Modules/PresentationKit/Sources/Features/MainTabBar/MainTabBar.swift
@@ -1,8 +1,8 @@
 //
-//  Login.swift
+//  MainTabBar.swift
 //  PresentationKit
 //
-//  Created by 고병학 on 9/30/23.
+//  Created by 고병학 on 10/1/23.
 //  Copyright © 2023 kr.ddd.ozeon. All rights reserved.
 //
 
@@ -10,7 +10,7 @@ import ComposableArchitecture
 
 import Foundation
 
-public struct Login: Reducer {
+public struct MainTabBar: Reducer {
     public init() {}
     
     public struct State: Equatable {
@@ -18,18 +18,12 @@ public struct Login: Reducer {
     }
     
     public enum Action {
-        case didTapLookAround
+        
     }
-    
-    @Dependency(\.dismiss) var dismiss
     
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
-            case .didTapLookAround:
-                return .run { _ in
-                    await self.dismiss()
-                }
             default:
                 return .none
             }

--- a/Projects/Modules/PresentationKit/Sources/Features/MainTabBar/MainTabBarView.swift
+++ b/Projects/Modules/PresentationKit/Sources/Features/MainTabBar/MainTabBarView.swift
@@ -1,0 +1,35 @@
+//
+//  MainTabBarView.swift
+//  PresentationKit
+//
+//  Created by 고병학 on 10/1/23.
+//  Copyright © 2023 kr.ddd.ozeon. All rights reserved.
+//
+
+import ComposableArchitecture
+
+import SwiftUI
+
+public struct MainTabBarView: View {
+    
+    let store: StoreOf<MainTabBar>
+    
+    public init(store: StoreOf<MainTabBar>) {
+        self.store = store
+    }
+    
+    public var body: some View {
+        Text("MainTabBar")
+    }
+}
+
+#if DEBUG
+struct MainTabBarView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainTabBarView(store: Store(initialState: MainTabBar.State()) {
+            MainTabBar()
+        })
+    }
+}
+
+#endif

--- a/Projects/Modules/PresentationKit/Sources/Features/Onboarding/Onboarding.swift
+++ b/Projects/Modules/PresentationKit/Sources/Features/Onboarding/Onboarding.swift
@@ -34,6 +34,7 @@ public struct Onboarding: Reducer {
     public enum Action {
         case pressNextStep
         case presentLogin
+        case switchToMainTabBar
         
         case login(PresentationAction<Login.Action>)
     }
@@ -48,9 +49,14 @@ public struct Onboarding: Reducer {
                     return .send(.presentLogin)
                 }
                 return .none
+                
             case .presentLogin:
                 state.login = .init()
                 return .none
+                
+            case .login(.dismiss):
+                return .send(.switchToMainTabBar)
+                
             default:
                 return .none
             }

--- a/Projects/Modules/PresentationKit/Sources/Features/Root/Root.swift
+++ b/Projects/Modules/PresentationKit/Sources/Features/Root/Root.swift
@@ -12,18 +12,38 @@ import Foundation
 
 public struct Root: Reducer {
     public init() {}
-    public struct State: Equatable {
-        public init() {}
-    }
-    public enum Action {
+    
+    public enum State: Equatable {
+        case onboarding(Onboarding.State)
+        case mainTabBar(MainTabBar.State)
         
+        public init() { self = .onboarding(.init()) }
     }
+    
+    public enum Action {
+        case presentOnboarding
+        case presentMainTabBar
+        
+        case onboarding(Onboarding.Action)
+        case mainTabBar(MainTabBar.Action)
+    }
+    
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+            case .onboarding(.switchToMainTabBar):
+                state = .mainTabBar(.init())
+                return .none
+                
             default:
                 return .none
             }
+        }
+        .ifCaseLet(/State.onboarding, action: /Action.onboarding) {
+            Onboarding()
+        }
+        .ifCaseLet(/State.mainTabBar, action: /Action.mainTabBar) {
+            MainTabBar()
         }
     }
 }

--- a/Projects/Modules/PresentationKit/Sources/Features/Root/RootView.swift
+++ b/Projects/Modules/PresentationKit/Sources/Features/Root/RootView.swift
@@ -19,20 +19,31 @@ public struct RootView: View {
     }
     
     public var body: some View {
-        WithViewStore(self.store, observe: { $0 }) { viewStore in
-            Text("Root View")
+        SwitchStore(store) { state in
+            switch state {
+            case .mainTabBar:
+                CaseLet(
+                    /Root.State.mainTabBar,
+                    action: Root.Action.mainTabBar
+                ) { store in
+                    MainTabBarView(store: store)
+                }
+            case .onboarding:
+                CaseLet(
+                    /Root.State.onboarding,
+                     action: Root.Action.onboarding
+                ) { store in
+                    OnboardingView(store: store)
+                }
+            }
         }
     }
 }
 
 struct RootView_Previews: PreviewProvider {
     static var previews: some View {
-        RootView(
-            store: Store(
-                initialState: Root.State(),
-                reducer: {
-                    Root()
-                })
-        )
+        RootView(store: Store(initialState: Root.State()) {
+            Root()
+        })
     }
 }

--- a/Projects/Modules/PresentationKit/Sources/Features/Splash/Splash.swift
+++ b/Projects/Modules/PresentationKit/Sources/Features/Splash/Splash.swift
@@ -16,7 +16,6 @@ public struct Splash: Reducer {
     public struct State: Equatable {
         public init() {}
         var isNeedToDismiss: Bool = false
-        
         @BindingState var isLogoHidden: Bool = true
         @BindingState var isTextHidden: Bool = true
     }
@@ -24,9 +23,7 @@ public struct Splash: Reducer {
     public enum Action {
         case appearLogoImage
         case appearText
-        
-        case presentOnboarding
-        case presentMainTab
+        case presentRootView
     }
     
     @Dependency(\.continuousClock) var clock
@@ -43,16 +40,9 @@ public struct Splash: Reducer {
                 state.isTextHidden = false
                 return .run { send in
                     try await self.clock.sleep(for: .seconds(1))
-                    let isLoginUser: Bool = false
-                    if isLoginUser {
-                        await send(.presentMainTab)
-                    } else {
-                        await send(.presentOnboarding)
-                    }
+                    await send(.presentRootView)
                 }
-            case .presentOnboarding:
-                return .none
-            case .presentMainTab:
+            case .presentRootView:
                 return .none
             }
         }

--- a/Projects/OZeon/Sources/AppFeature.swift
+++ b/Projects/OZeon/Sources/AppFeature.swift
@@ -16,30 +16,27 @@ public struct AppFeature: Reducer {
     
     public enum State: Equatable {
         case splash(Splash.State)
-        case onboarding(Onboarding.State)
+        case root(Root.State)
         
         public init() { self = .splash(Splash.State()) }
     }
     
     public enum Action {
         case presentSplashView
-        case presentOnboardingView
-        case presentMainTabView
+        case presentRootView
         
         case splash(Splash.Action)
-        case onboarding(Onboarding.Action)
+        case root(Root.Action)
     }
     
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
-            case .splash(.presentOnboarding):
-                return .send(.presentOnboardingView)
-            case .splash(.presentMainTab):
-                return .send(.presentMainTabView)
+            case .splash(.presentRootView):
+                return .send(.presentRootView)
 
-            case .presentOnboardingView:
-                state = .onboarding(.init())
+            case .presentRootView:
+                state = .root(.init())
                 return .none
 
             default:
@@ -49,8 +46,8 @@ public struct AppFeature: Reducer {
         .ifCaseLet(/State.splash, action: /Action.splash) {
             Splash()
         }
-        .ifCaseLet(/State.onboarding, action: /Action.onboarding) {
-            Onboarding()
+        .ifCaseLet(/State.root, action: /Action.root) {
+            Root()
         }
     }
 }

--- a/Projects/OZeon/Sources/AppView.swift
+++ b/Projects/OZeon/Sources/AppView.swift
@@ -28,12 +28,12 @@ public struct AppView: View {
                 ) { store in
                     SplashView(store: store)
                 }
-            case .onboarding:
+            case .root:
                 CaseLet(
-                    /AppFeature.State.onboarding,
-                    action: AppFeature.Action.onboarding
+                    /AppFeature.State.root,
+                    action: AppFeature.Action.root
                 ) { store in
-                    OnboardingView(store: store)
+                    RootView(store: store)
                 }
             }
         }


### PR DESCRIPTION
- Move onboarding, mainTabBar to sub-node of Root node

## PR

### 설명
<!-- 이 풀 리퀘스트로 제안하는 변경 사항 또는 추가 사항에 대해 간단히 설명해주세요. -->
- Onboarding, MainTabBar 노드를 Root 노드의 하위 노드로 변경
![](https://user-images.githubusercontent.com/41236155/271788345-04d2fb4b-6f6b-4b55-be43-8911335499f9.png)


### 관련 이슈
<!-- closes #이슈넘버 -->
<!-- ex) closes #2 -->
closes #75 

### 체크리스트
풀 리퀘스트가 다음 요구 사항을 모두 충족하도록 해주세요:

- [x] Warning이 없는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 코드 컨벤션을 준수했는지 확인
- [x] Preview 코드에 `#if DEBUG`, `#endif` 넣었는지 확인하기
- [x] 뷰 코드에 `enum Constants` 추가했는지 확인하기

### 추가 사항 (해당하는 경우)
<!-- 검토어들에게 도움이 될 수 있는 추가 정보나 문맥을 추가해주세요. -->

### 스크린샷 (해당하는 경우)
<!-- 변경 사항에 UI 또는 시각적 수정이 포함된 경우, 관련 스크린샷을 추가해보세요. -->
