### PR TITLE
[Feat] Implement custom navigation bar

### DIFF
--- a/Projects/Modules/DesignSystemKit/Sources/Buttons/ButtonContent/ImageButtonContent.swift
+++ b/Projects/Modules/DesignSystemKit/Sources/Buttons/ButtonContent/ImageButtonContent.swift
@@ -1,0 +1,19 @@
+//
+//  ImageButtonContent.swift
+//  DesignSystemKit
+//
+//  Created by 고병학 on 10/1/23.
+//  Copyright © 2023 kr.ddd.ozeon. All rights reserved.
+//
+
+import SwiftUI
+
+public struct ImageButtonContent {
+    public init(image: Image, action: @escaping () -> Void) {
+        self.image = image
+        self.action = action
+    }
+    
+    public let image: Image
+    public let action: () -> Void
+}

--- a/Projects/Modules/DesignSystemKit/Sources/Buttons/ButtonContent/TextButtonContent.swift
+++ b/Projects/Modules/DesignSystemKit/Sources/Buttons/ButtonContent/TextButtonContent.swift
@@ -1,0 +1,19 @@
+//
+//  TextButtonContent.swift
+//  DesignSystemKit
+//
+//  Created by 고병학 on 10/1/23.
+//  Copyright © 2023 kr.ddd.ozeon. All rights reserved.
+//
+
+import Foundation
+
+public struct TextButtonContent {
+    public init(text: String, action: @escaping () -> Void) {
+        self.text = text
+        self.action = action
+    }
+    
+    public let text: String
+    public let action: () -> Void
+}

--- a/Projects/Modules/DesignSystemKit/Sources/NavigationBar/CustomTabNavBar.swift
+++ b/Projects/Modules/DesignSystemKit/Sources/NavigationBar/CustomTabNavBar.swift
@@ -1,0 +1,106 @@
+//
+//  CustomTabNavBar.swift
+//  DesignSystemKit
+//
+//  Created by 고병학 on 10/1/23.
+//  Copyright © 2023 kr.ddd.ozeon. All rights reserved.
+//
+
+import SwiftUI
+
+public struct TextButtonContent {
+    public init(text: String, action: @escaping () -> Void) {
+        self.text = text
+        self.action = action
+    }
+    
+    public let text: String
+    public let action: () -> Void
+}
+
+public struct ImageButtonContent {
+    public init(image: Image, action: @escaping () -> Void) {
+        self.image = image
+        self.action = action
+    }
+    
+    public let image: Image
+    public let action: () -> Void
+}
+
+public struct CustomTabNavBar: View {
+    
+    public init(
+        tabButtons: [TextButtonContent],
+        selectedTab: Int,
+        buttons: [ImageButtonContent]
+    ) {
+        self.tabButtons = tabButtons
+        self.selectedTab = selectedTab
+        self.buttons = buttons
+    }
+    
+    let selectedTab: Int
+    let tabButtons: [TextButtonContent]
+    let buttons: [ImageButtonContent]
+    
+    public var body: some View {
+        ZStack {
+            HStack(spacing: 16) {
+                ForEach(Array(tabButtons.enumerated()), id: \.0) { (index, content) in
+                    Text(content.text)
+                        .font(
+                            selectedTab == index ? .Head2.semiBold
+                            : .Head2.regular
+                        )
+                        .foregroundColor(
+                            selectedTab == index ? Color.orangeGray1
+                            : Color.orangeGray5
+                        )
+                }
+                Spacer()
+            }
+            HStack(spacing: 16) {
+                Spacer()
+                ForEach(Array(buttons.enumerated()), id: \.0) { (_, content) in
+                    Button(action: content.action, label: {
+                        content.image
+                            .frame(width: 24, height: 24)
+                    })
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 17)
+        .padding(.bottom, 16)
+    }
+}
+
+#if DEBUG
+struct CustomTabNavBar_PreViews: PreviewProvider {
+    static var previews: some View {
+        CustomTabNavBar(
+            tabButtons: [
+                TextButtonContent(text: "최신순", action: {}),
+                TextButtonContent(text: "인기순", action: {})
+            ],
+            selectedTab: 1,
+            buttons: [
+                ImageButtonContent(
+                    image: DesignSystemKitAsset.icShare24.swiftUIImage,
+                    action: {}
+                ),
+                ImageButtonContent(
+                    image: DesignSystemKitAsset.icSearch24.swiftUIImage,
+                    action: {}
+                ),
+                ImageButtonContent(
+                    image: DesignSystemKitAsset.icFilter24.swiftUIImage,
+                    action: {}
+                )
+            ]
+        )
+    
+    }
+}
+#endif

--- a/Projects/Modules/DesignSystemKit/Sources/NavigationBar/CustomTabNavBar.swift
+++ b/Projects/Modules/DesignSystemKit/Sources/NavigationBar/CustomTabNavBar.swift
@@ -8,26 +8,6 @@
 
 import SwiftUI
 
-public struct TextButtonContent {
-    public init(text: String, action: @escaping () -> Void) {
-        self.text = text
-        self.action = action
-    }
-    
-    public let text: String
-    public let action: () -> Void
-}
-
-public struct ImageButtonContent {
-    public init(image: Image, action: @escaping () -> Void) {
-        self.image = image
-        self.action = action
-    }
-    
-    public let image: Image
-    public let action: () -> Void
-}
-
 public struct CustomTabNavBar: View {
     
     public init(

--- a/Projects/Modules/DesignSystemKit/Sources/NavigationBar/LargeTitleNavBar.swift
+++ b/Projects/Modules/DesignSystemKit/Sources/NavigationBar/LargeTitleNavBar.swift
@@ -1,0 +1,71 @@
+//
+//  LargeTitleNavBar.swift
+//  DesignSystemKit
+//
+//  Created by 고병학 on 10/1/23.
+//  Copyright © 2023 kr.ddd.ozeon. All rights reserved.
+//
+
+import SwiftUI
+
+public struct LargeTitleNavBar: View {
+    public init(
+        title: String,
+        rightButtons: [ImageButtonContent] = [],
+        backButtonAction: @escaping () -> Void
+    ) {
+        self.title = title
+        self.backButtonAction = backButtonAction
+        self.rightButtons = rightButtons
+    }
+    
+    let title: String
+    let backButtonAction: () -> Void
+    let rightButtons: [ImageButtonContent]
+    
+    public var body: some View {
+        ZStack {
+            HStack {
+                Button(action: backButtonAction, label: {
+                    DesignSystemKitAsset.icBack24.swiftUIImage
+                        .frame(width: 24, height: 24)
+                })
+                Spacer()
+            }
+            HStack(spacing: 16) {
+                Spacer()
+                ForEach(Array(rightButtons.enumerated()), id: \.0) { (_, content) in
+                    Button(action: content.action, label: {
+                        content.image
+                            .frame(width: 24, height: 24)
+                    })
+                }
+            }
+            
+            Text(title)
+                .font(.Head2.semiBold)
+                .multilineTextAlignment(.center)
+                .foregroundColor(Color.orangeGray1)
+        }
+        .frame(maxWidth: .infinity, minHeight: 24, maxHeight: 24)
+        .padding(.horizontal, 16)
+        .padding(.top, 17)
+        .padding(.bottom, 16)
+    }
+}
+
+#if DEBUG
+struct LargeTitleNavBar_Previews: PreviewProvider {
+    static var previews: some View {
+        LargeTitleNavBar(
+            title: "추천",
+            rightButtons: [
+                .init(image: DesignSystemKitAsset.icShare24.swiftUIImage, action: {}),
+                .init(image: DesignSystemKitAsset.icSearch24.swiftUIImage, action: {}),
+                .init(image: DesignSystemKitAsset.icFilter24.swiftUIImage, action: {})
+            ],
+            backButtonAction: {}
+        )
+    }
+}
+#endif

--- a/Projects/Modules/DesignSystemKit/Sources/NavigationBar/PaginationNavBar.swift
+++ b/Projects/Modules/DesignSystemKit/Sources/NavigationBar/PaginationNavBar.swift
@@ -1,0 +1,63 @@
+//
+//  PaginationNavBar.swift
+//  DesignSystemKit
+//
+//  Created by 고병학 on 10/1/23.
+//  Copyright © 2023 kr.ddd.ozeon. All rights reserved.
+//
+
+import SwiftUI
+
+public struct PaginationNavBar: View {
+    public init(
+        title: String,
+        numberOfPages: Int,
+        currentPage: Int,
+        backButtonAction: @escaping () -> Void
+    ) {
+        self.title = title
+        self.numberOfPages = numberOfPages
+        self.currentPage = currentPage
+        self.backButtonAction = backButtonAction
+    }
+    
+    let title: String
+    let numberOfPages: Int
+    let currentPage: Int
+    let backButtonAction: () -> Void
+    
+    public var body: some View {
+        ZStack {
+            HStack {
+                Button(action: backButtonAction, label: {
+                    DesignSystemKitAsset.icBack24.swiftUIImage
+                        .frame(width: 24, height: 24)
+                })
+                Spacer()
+                PageIndicator(numberOfPages: numberOfPages, currentPage: currentPage)
+            }
+            
+            Text(title)
+                .font(.Head2.semiBold)
+                .multilineTextAlignment(.center)
+                .foregroundColor(Color.orangeGray1)
+        }
+        .frame(maxWidth: .infinity, minHeight: 24, maxHeight: 24)
+        .padding(.horizontal, 16)
+        .padding(.top, 17)
+        .padding(.bottom, 16)
+    }
+}
+
+#if DEBUG
+struct PaginationNavBar_Previews: PreviewProvider {
+    static var previews: some View {
+        PaginationNavBar(
+            title: "닉네임 설정",
+            numberOfPages: 3,
+            currentPage: 1,
+            backButtonAction: {}
+        )
+    }
+}
+#endif

--- a/Projects/Modules/DesignSystemKit/Sources/NavigationBar/TitleNavBar.swift
+++ b/Projects/Modules/DesignSystemKit/Sources/NavigationBar/TitleNavBar.swift
@@ -1,0 +1,69 @@
+//
+//  TitleNavBar.swift
+//  DesignSystemKit
+//
+//  Created by 고병학 on 10/1/23.
+//  Copyright © 2023 kr.ddd.ozeon. All rights reserved.
+//
+
+import SwiftUI
+
+public struct TitleNavBar: View {
+    public init(
+        title: String,
+        rightButtons: [ImageButtonContent] = [],
+        backButtonAction: @escaping () -> Void
+    ) {
+        self.title = title
+        self.backButtonAction = backButtonAction
+        self.rightButtons = rightButtons
+    }
+    
+    let title: String
+    let backButtonAction: () -> Void
+    let rightButtons: [ImageButtonContent]
+    
+    public var body: some View {
+        ZStack {
+            HStack {
+                Button(action: backButtonAction, label: {
+                    DesignSystemKitAsset.icBack24.swiftUIImage
+                        .frame(width: 24, height: 24)
+                })
+                Spacer()
+            }
+            HStack(spacing: 16) {
+                Spacer()
+                ForEach(Array(rightButtons.enumerated()), id: \.0) { (_, content) in
+                    Button(action: content.action, label: {
+                        content.image
+                            .frame(width: 24, height: 24)
+                    })
+                }
+            }
+            
+            Text(title)
+                .font(.Title2.semiBold)
+                .multilineTextAlignment(.center)
+                .foregroundColor(Color.orangeGray1)
+        }
+        .frame(maxWidth: .infinity, minHeight: 24, maxHeight: 24)
+        .padding(.horizontal, 16)
+        .padding(.top, 17)
+        .padding(.bottom, 16)
+    }
+}
+
+#if DEBUG
+struct TitleNavBar_Previews: PreviewProvider {
+    static var previews: some View {
+        TitleNavBar(
+            title: "추천",
+            rightButtons: [
+                .init(image: DesignSystemKitAsset.icSearch24.swiftUIImage, action: {})
+            ],
+            backButtonAction: {}
+        )
+    }
+}
+#endif


### PR DESCRIPTION
## PR

### 설명
<!-- 이 풀 리퀘스트로 제안하는 변경 사항 또는 추가 사항에 대해 간단히 설명해주세요. -->
- 검색필드가 없는 커스텀 네비게이션 바 구현

### 관련 이슈
<!-- closes #이슈넘버 -->
<!-- ex) closes #2 -->
#24 

### 체크리스트
풀 리퀘스트가 다음 요구 사항을 모두 충족하도록 해주세요:

- [x] Warning이 없는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 코드 컨벤션을 준수했는지 확인
- [x] Preview 코드에 `#if DEBUG`, `#endif` 넣었는지 확인하기
- [ ] 뷰 코드에 `enum Constants` 추가했는지 확인하기

### 추가 사항 (해당하는 경우)
<!-- 검토어들에게 도움이 될 수 있는 추가 정보나 문맥을 추가해주세요. -->

### 스크린샷 (해당하는 경우)
<!-- 변경 사항에 UI 또는 시각적 수정이 포함된 경우, 관련 스크린샷을 추가해보세요. -->
<img width="596" alt="image" src="https://github.com/DDD-Community/SamsunPark-BornSoup-iOS/assets/41236155/4206e1be-cb4e-4723-925c-beb5dc6e09af">

<img width="587" alt="image" src="https://github.com/DDD-Community/SamsunPark-BornSoup-iOS/assets/41236155/aa3f0e12-8a40-4995-b2ef-99fbd334ef5f">

<img width="573" alt="image" src="https://github.com/DDD-Community/SamsunPark-BornSoup-iOS/assets/41236155/c5c6667a-2701-4f3a-8f8e-5d87cd81aeee">

<img width="574" alt="스크린샷 2023-10-01 오후 6 03 13" src="https://github.com/DDD-Community/SamsunPark-BornSoup-iOS/assets/41236155/58115bdb-4c32-472e-9dc3-a0642e8c3a17">
